### PR TITLE
feat: add local skills for offline component discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,22 @@ For Cursor, VS Code Copilot, Windsurf, and other tools, see the [Skills repo](ht
 - "Build an authentication flow with Cognito"
 - "Show me all chart components"
 
-### Option 2: File Copy
+### Option 2: Local Skills (No MCP Required)
+
+Install skills that read source files directly from this repo — works offline, no server needed:
+
+```bash
+npx skills add signerlabs/ShipSwift
+```
+
+Your AI can then browse the component catalog and read source code locally. Try:
+- "Explore ShipSwift recipes"
+- "Add a shimmer animation"
+- "Build a chat feature"
+
+> **Tip**: If you also connect the MCP server (Option 1), your AI gets access to additional Pro recipes (backend guides, compliance templates, pitfall docs).
+
+### Option 3: File Copy
 
 1. Clone this repository
 2. Copy the files you need from `ShipSwift/SWPackage/` into your Xcode project

--- a/skills/add-component/SKILL.md
+++ b/skills/add-component/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: add-component
+description: >
+  Add a SwiftUI component from ShipSwift. Use when the user says "add component",
+  "add a view", "add X view", "I need a chart", "add animation", or wants a specific UI element.
+---
+
+# Add Component from ShipSwift
+
+Add production-ready SwiftUI components to your project from ShipSwift's local source library.
+
+## Workflow
+
+1. **Identify the component**: Read `skills/catalog.md` to find the right component. Common mappings:
+   - "shimmer" / "loading skeleton" → `SWAnimation/SWShimmer.swift`
+   - "donut chart" / "pie chart" → `SWChart/SWDonutChart.swift`
+   - "alert" / "popup" → `SWComponent/Feedback/SWAlert.swift`
+   - "auth" / "login" → `SWModule/SWAuth/` (all files)
+   - "camera" → `SWModule/SWCamera/` (all files)
+
+2. **Read the source file**: Read the Swift file from `ShipSwift/SWPackage/<path>`. The file contains the complete implementation.
+
+3. **Integrate into the project**:
+   - Copy the file(s) into the user's project
+   - Also copy `SWUtil/` if not already present
+   - Adapt naming, colors, and data models to match the project
+   - For `+iOS`/`+macOS` files, set the platform filter in Xcode Build Phases
+
+4. **Verify**: Walk through any dependencies or setup steps needed.
+
+## Guidelines
+
+- Types use `SW` prefix (`SWDonutChart`, `SWTypewriter`).
+- View modifiers use `.sw` prefix (`.swShimmer()`, `.swGlowScan()`).
+- Chart components use a generic `CategoryType` pattern with `String` convenience initializer.
+- Internal helper types should be `private` with `SW` prefix.
+- Components in `SWAnimation/`, `SWChart/`, and `SWComponent/` are each self-contained (single file + SWUtil).
+- Modules in `SWModule/` are multi-file — copy the entire folder.

--- a/skills/build-feature/SKILL.md
+++ b/skills/build-feature/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: build-feature
+description: >
+  Build an iOS feature using ShipSwift components. Use when the user says
+  "build", "create", "add a feature", or describes an iOS feature they want to implement.
+---
+
+# Build Feature with ShipSwift
+
+Build production-ready iOS features by combining ShipSwift components — copy-paste-ready SwiftUI implementations covering animations, charts, UI components, and full-stack modules.
+
+## Workflow
+
+1. **Browse the catalog**: Read `skills/catalog.md` to see all available components organized by category.
+
+2. **Read the source**: For each relevant component, read the Swift file directly from `ShipSwift/SWPackage/`. For example:
+   - Shimmer animation → read `ShipSwift/SWPackage/SWAnimation/SWShimmer.swift`
+   - Donut chart → read `ShipSwift/SWPackage/SWChart/SWDonutChart.swift`
+   - Auth module → read all files in `ShipSwift/SWPackage/SWModule/SWAuth/`
+
+3. **Present an integration plan**: Before writing code, show the user:
+   - Which components will be used
+   - How they connect together
+   - What customizations are needed
+
+4. **Generate code**: Adapt the component patterns to the user's project. Combine multiple components when the feature spans several areas (e.g., a chart view with shimmer loading).
+
+5. **Integration checklist**: List required dependencies, Info.plist entries, or Xcode build phase settings (especially for `+iOS`/`+macOS` platform-filtered files).
+
+## Guidelines
+
+- Always check the catalog before writing code from scratch — ShipSwift likely has a ready-made solution.
+- Use `SW`-prefixed naming (`SWShimmer`, `SWDonutChart`).
+- View modifiers use `.sw` lowercase prefix (`.swShimmer()`, `.swGlowScan()`).
+- Copy `SWUtil/` alongside any component — it provides shared extensions.
+- For modules (`SWModule/`), copy the entire module folder.
+- Support Dark Mode and Dynamic Type by default.
+
+## Pro Recipes (MCP)
+
+Some full-stack recipes (backend + compliance + pitfall guides) are available via the MCP server at `https://api.shipswift.app/mcp`. If MCP tools (`listRecipes`, `searchRecipes`, `getRecipe`) are available, use them for extended content. The local source code works independently.

--- a/skills/catalog.md
+++ b/skills/catalog.md
@@ -1,0 +1,102 @@
+# ShipSwift Recipe Catalog
+
+All source files are under `ShipSwift/SWPackage/`. Each component is self-contained — copy the file(s) plus `SWUtil/` into your project.
+
+## Animation (`SWAnimation/`)
+
+| Component | File | Description |
+|-----------|------|-------------|
+| AnimatedMeshGradient | `SWAnimatedMeshGradient.swift` | Animated mesh gradient background |
+| BeforeAfterSlider | `SWBeforeAfterSlider.swift` | Drag-to-compare before/after image slider |
+| GlowSweep | `SWGlowSweep.swift` | Glowing sweep animation overlay |
+| LightSweep | `SWLightSweep.swift` | Light sweep / skeleton loading effect |
+| OrbitingLogos | `SWOrbitingLogos.swift` | Logos orbiting around a center point |
+| ScanningOverlay | `SWScanningOverlay.swift` | Scanning line animation overlay |
+| ShakingIcon | `SWShakingIcon.swift` | Icon with shake animation on trigger |
+| Shimmer | `SWShimmer.swift` | Shimmer / skeleton loading placeholder |
+| TypewriterText | `SWTypewriterText.swift` | Character-by-character typing animation |
+
+## Chart (`SWChart/`)
+
+| Component | File | Description |
+|-----------|------|-------------|
+| ActivityHeatmap | `SWActivityHeatmap.swift` | GitHub-style contribution heatmap |
+| AreaChart | `SWAreaChart.swift` | Filled area chart with gradient |
+| BarChart | `SWBarChart.swift` | Vertical bar chart |
+| DonutChart | `SWDonutChart.swift` | Donut / pie chart with center label |
+| LineChart | `SWLineChart.swift` | Line chart with markers |
+| RadarChart | `SWRadarChart.swift` | Spider / radar chart |
+| RingChart | `SWRingChart.swift` | Circular progress ring chart |
+| ScatterChart | `SWScatterChart.swift` | Scatter plot chart |
+
+## Component — Display (`SWComponent/Display/`)
+
+| Component | File | Description |
+|-----------|------|-------------|
+| BulletPointText | `SWBulletPointText.swift` | Styled bullet point list |
+| FloatingLabels | `SWFloatingLabels.swift` | Floating animated labels |
+| GradientDivider | `SWGradientDivider.swift` | Gradient-styled divider line |
+| Label | `SWLabel.swift` | Styled label with icon support |
+| MarkdownText | `SWMarkdownText.swift` | Markdown-rendered text view |
+| OnboardingView | `SWOnboardingView.swift` | Multi-page onboarding flow |
+| OrderView | `SWOrderView.swift` | Order / receipt summary view |
+| RootTabView | `SWRootTabView.swift` | Tab bar navigation root view |
+| RotatingQuote | `SWRotatingQuote.swift` | Auto-rotating quote display |
+| ScrollingFAQ | `SWScrollingFAQ+iOS.swift` | Expandable FAQ list (iOS) |
+
+## Component — Feedback (`SWComponent/Feedback/`)
+
+| Component | File | Description |
+|-----------|------|-------------|
+| Alert | `SWAlert.swift` | Custom alert with SWAlertManager |
+| Loading | `SWLoading.swift` | Page loading overlay |
+| ThinkingIndicator | `SWThinkingIndicator.swift` | AI thinking / typing indicator |
+
+## Component — Input (`SWComponent/Input/`)
+
+| Component | File | Description |
+|-----------|------|-------------|
+| AddSheet | `SWAddSheet.swift` | Bottom sheet for adding items |
+| Stepper | `SWStepper.swift` | Custom stepper control |
+| TabButton | `SWTabButton.swift` | Styled tab bar button |
+
+## Module (`SWModule/`)
+
+Multi-file modules. Copy the entire module folder plus `SWUtil/`.
+
+| Module | Files | Description |
+|--------|-------|-------------|
+| **SWAuth** | `SWAuthView+iOS.swift`, `SWAuthView+macOS.swift`, `SWUserManager.swift`, `SWCountryData.swift`, `SWAgreementChecker.swift` | Authentication with Amplify/Cognito — social login, email/password, phone sign-in with country code picker |
+| **SWCamera** | `SWCameraManager+iOS.swift`, `SWCameraView+iOS.swift`, `SWFaceCameraView+iOS.swift`, `SWFaceLandmark+iOS.swift` | Camera capture with viewfinder, zoom, photo picker, face detection with Vision landmarks |
+| **SWChat** | `SWChatView+iOS.swift`, `SWChatInputView+iOS.swift`, `SWMessageList+iOS.swift`, `SWVolcEngineASRService+iOS.swift` | Chat view with message list, text input, optional voice recognition (VolcEngine ASR) |
+| **SWPaywall** | `SWPaywallView.swift`, `SWStoreManager.swift` | StoreKit 2 subscription paywall |
+| **SWSetting** | `SWSettingView+iOS.swift`, `SWSettingView+macOS.swift` | Settings page with language switch, share, legal links |
+| **SWSubjectLifting** | `SWSubjectLiftingManager+iOS.swift`, `SWSubjectLiftingView+iOS.swift` | Background removal using VisionKit |
+| **SWTikTokTracking** | `SWTikTokTrackingManager+iOS.swift`, `SWTikTokTrackingView+iOS.swift` | TikTok Events API attribution tracking |
+
+## Utilities (`SWUtil/`)
+
+| File | Description |
+|------|-------------|
+| `SWDateExtension.swift` | Date formatting extensions |
+| `SWDebugLog.swift` | Debug logging utility |
+| `SWLocationManager.swift` | Location manager wrapper |
+| `SWStringExtension.swift` | String utility extensions |
+| `SWViewExtension.swift` | View modifier extensions (`.swAlert()`, `.swPageLoading()`, `.swPrimary`) |
+
+## Dependency Rules
+
+```
+SWUtil         ← no dependencies
+SWAnimation    ← SWUtil only
+SWChart        ← SWUtil only
+SWComponent    ← SWUtil only
+SWModule       ← SWUtil + SWComponent + same-module files
+```
+
+## Naming Conventions
+
+- Types: `SW` prefix (`SWAlertManager`, `SWStoreManager`)
+- View modifiers: `.sw` prefix (`.swAlert()`, `.swPageLoading()`)
+- iOS-only files: `+iOS` suffix
+- macOS-only files: `+macOS` suffix

--- a/skills/explore-recipes/SKILL.md
+++ b/skills/explore-recipes/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: explore-recipes
+description: >
+  Explore and browse available ShipSwift components. Use when the user says
+  "explore", "browse", "show recipes", "list components", "what's available",
+  or wants to discover what ShipSwift offers.
+---
+
+# Explore ShipSwift Recipes
+
+Browse the full catalog of ShipSwift components — production-ready SwiftUI implementations.
+
+## Workflow
+
+1. **Show the catalog**: Read `skills/catalog.md` and present components organized by category:
+
+   | Category | Count | Examples |
+   |----------|-------|---------|
+   | Animation | 9 | Shimmer, Typewriter, GlowSweep, MeshGradient, OrbitingLogos |
+   | Chart | 8 | Line, Bar, Area, Donut, Ring, Radar, Scatter, Heatmap |
+   | Component | 13 | Alert, Loading, Onboarding, Stepper, FloatingLabels |
+   | Module | 7 | Auth, Camera, Chat, Paywall, Settings, SubjectLifting, TikTokTracking |
+   | Util | 5 | Date/String/View extensions, DebugLog, LocationManager |
+
+2. **Show details on request**: When the user picks a component, read the source file and present:
+   - What it does
+   - Key features and customization points
+   - Code structure overview
+   - Dependencies
+
+3. **Suggest combinations**: Recommend components that work well together:
+   - **Onboarding flow**: OnboardingView + TypewriterText + Shimmer
+   - **Analytics dashboard**: LineChart + BarChart + DonutChart + ActivityHeatmap
+   - **Social feature**: Camera + Chat + Auth
+   - **E-commerce**: OrderView + Loading + Alert + Stepper
+
+## Guidelines
+
+- Present in a scannable format (tables or bullet lists).
+- When showing details, include the file path so the user can find it.
+- All source is local under `ShipSwift/SWPackage/` — no network required.


### PR DESCRIPTION
## What

Adds a `skills/` directory so users can install ShipSwift skills that work **locally without MCP**.

```bash
npx skills add signerlabs/ShipSwift
```

## Why

The current setup requires both `npx skills add signerlabs/shipswift-skills` **and** a separate MCP server configuration. This is a barrier for users who:
- Just want to use the open-source components
- Don't need Pro recipes (backend/compliance/pitfall guides)
- Want offline access

## What's included

| File | Purpose |
|------|---------|
| `skills/catalog.md` | Structured index of all 59 components with descriptions and file paths |
| `skills/build-feature/SKILL.md` | Workflow for building features by combining components |
| `skills/add-component/SKILL.md` | Workflow for adding a specific component to a project |
| `skills/explore-recipes/SKILL.md` | Workflow for browsing the full catalog |

## How it works

Skills instruct the AI to:
1. Read `catalog.md` for discovery
2. Read Swift source files directly from `SWPackage/`
3. Follow existing naming conventions from `CLAUDE.md`

No API, no network, no key. MCP remains the path for Pro content.

## README update

Added "Option 2: Local Skills" in Quick Start, between the MCP option and file copy.