### PR TITLE
fix: wrap SWOrderView content in ScrollView on iOS to prevent button clipping

### DIFF
--- a/ShipSwift/SWPackage/SWComponent/Display/SWOrderView.swift
+++ b/ShipSwift/SWPackage/SWComponent/Display/SWOrderView.swift
@@ -55,14 +55,10 @@ struct SWOrderView: View {
     var body: some View {
         ZStack {
             backgroundGradient
-            #if os(macOS)
             ScrollView {
                 contentView
                     .padding(.vertical)
             }
-            #else
-            contentView
-            #endif
         }
     }
     


### PR DESCRIPTION
## 问题
在 iOS 上打开 `SWOrderView`，底部的「Add to Cart」按钮会被屏幕底部裁切，且无法滚动到达。

在 iPhone 15 Pro 上实测：按钮底边在 875pt，而屏幕高仅 852pt，**被切掉约 23pt**。屏幕越小（如 iPhone SE）问题越严重。

## 原因
`body` 里只有 macOS 分支用了 `ScrollView`，iOS 分支直接渲染 `contentView`：

```swift
#if os(macOS)
ScrollView { contentView }
#else
contentView          // iOS 没有 ScrollView
#endif
```

而 `cupsSection` 在 iOS 上是固定高度 500，加上数量控件、两个选择器和按钮，总高超过屏幕，iOS 又不能滚动，导致按钮被挤出可视区。

## 修复
去掉平台判断，iOS / macOS 统一用 `ScrollView` 包裹，和原本 macOS 的行为保持一致。这样所有设备尺寸下内容都能滚动、按钮都能完整看到。

修复后在 iPhone 15 Pro 上验证：滚动到底部时按钮底边为 802pt（< 852），完整可见。